### PR TITLE
feat: expand messages for agents

### DIFF
--- a/src/lib/appManagers/appImManager.ts
+++ b/src/lib/appManagers/appImManager.ts
@@ -2439,12 +2439,6 @@ export class AppImManager extends EventListenerBase<{
     // const log = this.log.bindPrefix('getPeerTyping-' + peerId);
     // log('getting peer typing');
 
-    const isUser = peerId.isUser();
-    if(isUser && await this.managers.appUsersManager.isBot(peerId)) {
-      // log('a bot');
-      return;
-    }
-
     const typings = await this.managers.appProfileManager.getPeerTypings(peerId, threadId);
     if(!typings?.length) {
       // log('have no typing');

--- a/src/lib/appManagers/appMessagesManager.ts
+++ b/src/lib/appManagers/appMessagesManager.ts
@@ -2253,7 +2253,7 @@ export class AppMessagesManager extends AppManager {
     if(peerId !== fromId) {
       pFlags.out = true;
 
-      if(!this.appPeersManager.isChannel(peerId) && !this.appUsersManager.isBot(peerId)) {
+      if(!this.appPeersManager.isChannel(peerId)) {
         pFlags.unread = true;
       }
     }

--- a/src/lib/mtproto/api_methods.ts
+++ b/src/lib/mtproto/api_methods.ts
@@ -323,6 +323,7 @@ export default abstract class ApiManagerMethods extends AppManager {
       method: 'help.getConfig',
       params: {},
       processResult: (config) => {
+        config.message_length_max = 100000;
         this.config = config;
         this.rootScope.dispatchEvent('config', config);
         return config;


### PR DESCRIPTION
## Summary
- lift maximum message length to 100000 characters
- allow marking messages from bots as unread and show typing status for bots

## Testing
- `pnpm lint`
- `pnpm test` *(fails: srp.test.ts 2FA hash)*

------
https://chatgpt.com/codex/tasks/task_e_689c9ba12b4c8329b1cc4cc6a1c475bf