### PR TITLE
feat: require group selection on login

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@
           </div>
           <div class="tabs-tab page-password"></div>
           <div class="tabs-tab page-signUp"></div>
+          <div class="tabs-tab page-groupSelect"></div>
         </div>
       </div>
     </div>

--- a/src/pages/pageAuthCode.ts
+++ b/src/pages/pageAuthCode.ts
@@ -53,7 +53,7 @@ const submitCode = (code: string) => {
       case 'auth.authorization':
         await rootScope.managers.apiManager.setUser(response.user);
 
-        import('./pageIm').then((m) => {
+        import('./pageGroupSelect').then((m) => {
           m.default.mount();
         });
         cleanup();

--- a/src/pages/pageGroupSelect.ts
+++ b/src/pages/pageGroupSelect.ts
@@ -1,0 +1,68 @@
+import LoginPage from './loginPage';
+import Button from '../components/button';
+import rootScope from '../lib/rootScope';
+import {attachClickEvent} from '../helpers/dom/clickEvent';
+
+let page: LoginPage;
+
+const mount = () => {
+  if(!page) {
+    page = new LoginPage({
+      className: 'page-groupSelect',
+      withInputWrapper: true,
+      titleLangKey: 'GroupSelectTitle',
+      subtitleLangKey: 'GroupSelectSubtitle'
+    });
+
+    const searchInput = document.createElement('input');
+    searchInput.type = 'text';
+    searchInput.placeholder = 'Search groups';
+    searchInput.className = 'input-field';
+
+    const searchList = document.createElement('select');
+    searchList.size = 5;
+    searchList.style.display = 'none';
+
+    const groupInput = document.createElement('input');
+    groupInput.type = 'text';
+    groupInput.placeholder = 'Group ID';
+    groupInput.className = 'input-field';
+
+    searchInput.addEventListener('input', async() => {
+      const q = searchInput.value.trim();
+      if(!q) {
+        searchList.innerHTML = '';
+        searchList.style.display = 'none';
+        return;
+      }
+      const res: any = await rootScope.managers.apiManager.invokeApi('contacts.search', {q, limit: 5});
+      searchList.innerHTML = '';
+      const chats: any[] = res.chats || [];
+      chats.forEach((chat: any) => {
+        if(chat._ === 'chat' || chat._ === 'channel') {
+          const opt = document.createElement('option');
+          opt.value = '' + chat.id;
+          opt.textContent = chat.title;
+          searchList.append(opt);
+        }
+      });
+      searchList.style.display = searchList.children.length ? '' : 'none';
+    });
+
+    searchList.addEventListener('change', () => {
+      groupInput.value = searchList.value;
+    });
+
+    const btn = Button('btn-primary btn-color-primary', {text: 'Continue'});
+    attachClickEvent(btn, () => {
+      sessionStorage.setItem('selectedGroupId', groupInput.value);
+      import('./pageIm').then((m) => m.default.mount());
+    });
+
+    page.inputWrapper.append(searchInput, searchList, groupInput, btn);
+  }
+
+  page.element.style.display = '';
+};
+
+export default {mount};

--- a/src/pages/pageIm.ts
+++ b/src/pages/pageIm.ts
@@ -33,6 +33,17 @@ const onFirstMount = () => {
     'requestVideoFrameCallback' in HTMLVideoElement.prototype ? Promise.resolve() : import('../helpers/dom/requestVideoFrameCallbackPolyfill')
   ]).then(([appDialogsManager]) => {
     appDialogsManager.default.start();
+
+    const groupId = sessionStorage.getItem('selectedGroupId');
+    if(groupId) {
+      const idNum = parseInt(groupId, 10);
+      rootScope.managers.appImManager.open({peerId: idNum});
+      const leftColumn = document.getElementById('column-left');
+      if(leftColumn) {
+        leftColumn.style.display = 'none';
+      }
+    }
+
     document.body.classList.remove('has-auth-pages');
     setTimeout(() => {
       document.getElementById('auth-pages').remove();

--- a/src/pages/pagePassword.ts
+++ b/src/pages/pagePassword.ts
@@ -92,7 +92,7 @@ const onFirstMount = (): Promise<any> => {
       switch(response._) {
         case 'auth.authorization':
           clearInterval(getStateInterval);
-          import('./pageIm').then((m) => {
+          import('./pageGroupSelect').then((m) => {
             m.default.mount();
           });
           if(monkey) monkey.remove();

--- a/src/pages/pageSignImport.ts
+++ b/src/pages/pageSignImport.ts
@@ -26,7 +26,7 @@ const importWebToken = async() => {
 
     if(authorization._ === 'auth.authorization') {
       await rootScope.managers.apiManager.setUser(authorization.user);
-      mountPageAfter = import('./pageIm');
+      mountPageAfter = import('./pageGroupSelect');
       // return;
     }
   } catch(err) {

--- a/src/pages/pageSignIn.ts
+++ b/src/pages/pageSignIn.ts
@@ -144,7 +144,7 @@ const onFirstMount = () => {
         if(authorization._ === 'auth.authorization') {
           await rootScope.managers.apiManager.setUser(authorization.user);
 
-          import('./pageIm').then((m) => {
+          import('./pageGroupSelect').then((m) => {
             m.default.mount();
           });
         }

--- a/src/pages/pageSignQR.ts
+++ b/src/pages/pageSignQR.ts
@@ -98,7 +98,7 @@ const onFirstMount = async() => {
       if(loginToken._ === 'auth.loginTokenSuccess') {
         const authorization = loginToken.authorization as any as AuthAuthorization.authAuthorization;
         await rootScope.managers.apiManager.setUser(authorization.user);
-        import('./pageIm').then((m) => m.default.mount());
+        import('./pageGroupSelect').then((m) => m.default.mount());
         return true;
       }
 

--- a/src/pages/pageSignUp.ts
+++ b/src/pages/pageSignUp.ts
@@ -130,7 +130,7 @@ const onFirstMount = async() => {
           await rootScope.managers.apiManager.setUser(response.user);
 
           sendAvatar().finally(() => {
-            import('./pageIm').then((m) => {
+            import('./pageGroupSelect').then((m) => {
               m.default.mount();
             });
           });


### PR DESCRIPTION
## Summary
- add group selection page with search and ID input
- route sign in flow through new group selection page
- open only the chosen group and hide chat list

## Testing
- `pnpm lint`
- `pnpm test` *(fails: AssertionError in srp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cbe89d2408329a9e3c8c0233bc7b3