### PR TITLE
Rename Telegram branding and add log off

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## Telegram Web K
-Based on Webogram, patched and improved. Available for everyone here: https://web.telegram.org/k/
+## Indiana's Lighthouse Web K
+Based on Webogram, patched and improved. Available for everyone here: https://indiana.lighthouse/k/
 
 
 ### Developing
@@ -44,7 +44,7 @@ Source maps are included in production build for your convenience.
 * **test=1**: to use test DCs
 * **debug=1**: to enable additional logging
 * **noSharedWorker=1**: to disable Shared Worker, can be useful for debugging
-* **http=1**: to force the use of HTTPS transport when connecting to Telegram servers
+* **http=1**: to force the use of HTTPS transport when connecting to Indiana's Lighthouse servers
 
 Should be applied like that: http://localhost:8080/?test=1
 
@@ -53,7 +53,7 @@ You can also take and load snapshots of the local storage and indexed DB using t
 
 ### Troubleshooting & Suggesting
 
-If you find an issue with this app or wish something to be added, let Telegram know using the [Suggestions Platform](https://bugs.telegram.org/c/4002).
+If you find an issue with this app or wish something to be added, let Indiana's Lighthouse know using the [Suggestions Platform](https://bugs.indiana.lighthouse/c/4002).
 
 ### Licensing
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tweb",
+  "name": "indiana_lighthouse",
   "version": "1.0.0",
-  "description": "",
+  "description": "Indiana's Lighthouse web application",
   "main": "index.js",
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Telegram Web</title>
-    <meta name="description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
+    <title>Indiana's Lighthouse</title>
+    <meta name="description" content="Indiana's Lighthouse is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
     <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,shrink-to-fit=no,viewport-fit=cover"> 
     <meta name="mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-title" content="Telegram Web">
+    <meta name="mobile-web-app-title" content="Indiana's Lighthouse">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-title" content="Telegram Web">
-    <meta name="application-name" content="Telegram Web">
+    <meta name="apple-mobile-web-app-title" content="Indiana's Lighthouse">
+    <meta name="application-name" content="Indiana's Lighthouse">
     <meta name="msapplication-TileColor" content="#2d89ef">
     <meta name="msapplication-TileImage" content="assets/img/mstile-144x144.png?v=jw3mK7G9Ry">
     <meta name="msapplication-config" content="browserconfig.xml?v=jw3mK7G9Ry">
@@ -21,15 +21,15 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://web.telegram.org/k/">
-    <meta property="og:title" content="Telegram Web">
-    <meta property="og:description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
+    <meta property="og:title" content="Indiana's Lighthouse">
+    <meta property="og:description" content="Indiana's Lighthouse is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
     <meta property="og:image" content="assets/img/android-chrome-192x192.png?v=jw3mK7G9Ry">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://web.telegram.org/k/">
-    <meta property="twitter:title" content="Telegram Web">
-    <meta property="twitter:description" content="Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
+    <meta property="twitter:title" content="Indiana's Lighthouse">
+    <meta property="twitter:description" content="Indiana's Lighthouse is a cloud-based mobile and desktop messaging app with a focus on security and speed.">
     <meta property="twitter:image" content="assets/img/android-chrome-192x192.png?v=jw3mK7G9Ry">
 
     <link rel="apple-touch-icon" sizes="180x180" href="assets/img/apple-touch-icon.png?v=jw3mK7G9Ry">

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,8 +1,8 @@
 {
-    "name": "Telegram Web",
-    "short_name": "Telegram Web",
+    "name": "Indiana's Lighthouse",
+    "short_name": "Indiana's Lighthouse",
     "start_url": "./",
-    "description": "Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.",
+    "description": "Indiana's Lighthouse is a cloud-based mobile and desktop messaging app with a focus on security and speed.",
     "icons": [
         {
             "src": "assets/img/android-chrome-36x36.png?v=jw3mK7G9Ry",

--- a/public/site_apple.webmanifest
+++ b/public/site_apple.webmanifest
@@ -1,8 +1,8 @@
 {
-    "name": "Telegram Web",
-    "short_name": "Telegram Web",
+    "name": "Indiana's Lighthouse",
+    "short_name": "Indiana's Lighthouse",
     "start_url": "./",
-    "description": "Telegram is a cloud-based mobile and desktop messaging app with a focus on security and speed.",
+    "description": "Indiana's Lighthouse is a cloud-based mobile and desktop messaging app with a focus on security and speed.",
     "icons": [
         {
             "src": "assets/img/icon_square_192.png?v=jw3mK7G9Ry",

--- a/src/components/sidebarLeft/index.ts
+++ b/src/components/sidebarLeft/index.ts
@@ -718,6 +718,16 @@ export class AppSidebarLeft extends SidebarSlider {
       separator: true
     }, () => this.createNewChatsSubmenu());
 
+    const logOffBtn: typeof menuButtons[0] = {
+      icon: 'logout',
+      regularText: 'Log off',
+      onClick: () => {
+        closeTabsBefore(() => {
+          this.managers.apiManager.logOut();
+        });
+      }
+    };
+
     const menuButtons: (ButtonMenuItemOptions & {verify?: () => boolean | Promise<boolean>})[] = [{
       icon: 'plus',
       text: 'MultiAccount.AddAccount',
@@ -789,7 +799,7 @@ export class AppSidebarLeft extends SidebarSlider {
           this.createTab(AppSettingsTab).open();
         });
       }
-    }, moreSubmenu.menuBtnOptions];
+    }, logOffBtn, moreSubmenu.menuBtnOptions];
 
     const filteredButtons = menuButtons.filter(Boolean);
     const filteredButtonsSliced = filteredButtons.slice();


### PR DESCRIPTION
## Summary
- rebrand visible metadata from Telegram Web to Indiana's Lighthouse
- rename package to indiana_lighthouse
- add Log off button in sidebar tools menu

## Testing
- `pnpm test` *(fails: expected Uint8Array to deeply equal...)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ccb7effa48329a3f0b7e274458342