### PR TITLE
refactor: use async fs operations in build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const {spawn, execSync} = require('child_process');
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const keepAsset = require('./keepAsset');
 const {NodeSSH} = require('node-ssh');
@@ -18,43 +18,44 @@ child.stdout.on('data', (chunk) => {
 const publicPath = __dirname + '/public/';
 const distPath = __dirname + '/dist/';
 
-let sshConfig;
-try {
-  sshConfig = JSON.parse(fs.readFileSync(path.join(__dirname, 'ssh.json'), 'utf8'));
-} catch(err) {
-  console.log('No SSH config, skipping upload');
-}
-
-function copyFiles(source, destination) {
-  if(!fs.existsSync(destination)) {
-    fs.mkdirSync(destination);
+async function copyFiles(source, destination) {
+  try {
+    await fs.mkdir(destination, {recursive: true});
+    const files = await fs.readdir(source, {withFileTypes: true});
+    for(const file of files) {
+      const sourcePath = path.join(source, file.name);
+      const destinationPath = path.join(destination, file.name);
+      if(file.isFile()) {
+        await fs.copyFile(sourcePath, destinationPath);
+        console.log(`Copied file ${sourcePath} to ${destinationPath}`);
+      } else if(file.isDirectory()) {
+        await copyFiles(sourcePath, destinationPath);
+      }
+    }
+  } catch(err) {
+    console.error(`Error copying from ${source} to ${destination}:`, err);
+    throw err;
   }
-
-  const files = fs.readdirSync(source, {withFileTypes: true});
-  files.forEach((file) => {
-    const sourcePath = path.join(source, file.name);
-    const destinationPath = path.join(destination, file.name);
-
-    if(file.isFile()) {
-      fs.copyFileSync(sourcePath, destinationPath);
-    } else if(file.isDirectory()) {
-      copyFiles(sourcePath, destinationPath);
-    }
-  });
 }
 
-function clearOldFiles() {
-  const bundleFiles = fs.readdirSync(distPath);
-  const files = fs.readdirSync(publicPath, {withFileTypes: true});
-  files.forEach((file) => {
-    if(file.isDirectory() ||
-      bundleFiles.some((bundleFile) => bundleFile === file.name) ||
-      keepAsset(file.name)) {
-      return;
+async function clearOldFiles() {
+  try {
+    const bundleFiles = await fs.readdir(distPath);
+    const files = await fs.readdir(publicPath, {withFileTypes: true});
+    for(const file of files) {
+      if(file.isDirectory() ||
+        bundleFiles.some((bundleFile) => bundleFile === file.name) ||
+        keepAsset(file.name)) {
+        continue;
+      }
+      const filePath = path.join(publicPath, file.name);
+      await fs.unlink(filePath);
+      console.log(`Removed ${filePath}`);
     }
-
-    fs.unlinkSync(publicPath + file.name);
-  });
+  } catch(err) {
+    console.error('Error clearing old files:', err);
+    throw err;
+  }
 }
 
 child.on('close', (code) => {
@@ -84,59 +85,89 @@ child.on('close', (code) => {
 const ssh = new NodeSSH();
 const onCompiled = async() => {
   console.log('Compiled successfully.');
-  copyFiles(distPath, publicPath);
-  clearOldFiles();
+  try {
+    await copyFiles(distPath, publicPath);
+  } catch(err) {
+    console.error('Copying files failed:', err);
+  }
 
-  if(!sshConfig) {
+  try {
+    await clearOldFiles();
+  } catch(err) {
+    console.error('Clearing old files failed:', err);
+  }
+
+  let sshConfig;
+  try {
+    const config = await fs.readFile(path.join(__dirname, 'ssh.json'), 'utf8');
+    sshConfig = JSON.parse(config);
+  } catch(err) {
+    console.log('No SSH config, skipping upload');
     return;
   }
 
   const archiveName = 'archive.zip';
   const archivePath = path.join(__dirname, archiveName);
-  execSync(`zip -r ${archivePath} *`, {
-    cwd: publicPath
-  });
+  try {
+    execSync(`zip -r ${archivePath} *`, {
+      cwd: publicPath
+    });
+    console.log('Created archive');
+  } catch(err) {
+    console.error('Failed to create archive:', err);
+    return;
+  }
 
-  await ssh.connect({
-    ...sshConfig,
-    tryKeyboard: true
-  });
-  console.log('SSH connected');
-  await ssh.execCommand(`rm -rf ${sshConfig.publicPath}/*`);
-  console.log('Cleared old files');
-  await ssh.putFile(archivePath, path.join(sshConfig.publicPath, archiveName));
-  console.log('Uploaded archive');
-  await ssh.execCommand(`cd ${sshConfig.publicPath} && unzip ${archiveName} && rm ${archiveName}`);
-  console.log('Unzipped archive');
-  fs.unlinkSync(archivePath);
+  try {
+    await ssh.connect({
+      ...sshConfig,
+      tryKeyboard: true
+    });
+    console.log('SSH connected');
+    await ssh.execCommand(`rm -rf ${sshConfig.publicPath}/*`);
+    console.log('Cleared remote files');
+    await ssh.putFile(archivePath, path.join(sshConfig.publicPath, archiveName));
+    console.log('Uploaded archive');
+    await ssh.execCommand(`cd ${sshConfig.publicPath} && unzip ${archiveName} && rm ${archiveName}`);
+    console.log('Unzipped archive');
+  } catch(err) {
+    console.error('SSH operations failed:', err);
+  }
+
+  try {
+    await fs.unlink(archivePath);
+    console.log('Removed local archive');
+  } catch(err) {
+    console.error('Failed to remove local archive:', err);
+  }
   ssh.connection?.destroy();
 };
 
-function compressFolder(folderPath) {
+async function compressFolder(folderPath) {
   const archive = {};
 
-  function processFolder(folderPath, parentKey) {
+  async function processFolder(folderPath, parentKey) {
     const folderName = path.basename(folderPath);
     const folderKey = parentKey ? `${parentKey}/${folderName}` : folderName;
     archive[folderKey] = {};
 
-    const files = fs.readdirSync(folderPath);
+    const files = await fs.readdir(folderPath);
     for(const file of files) {
       const filePath = path.join(folderPath, file);
-      const stats = fs.statSync(filePath);
+      const stats = await fs.stat(filePath);
 
       if(stats.isFile()) {
-        const fileContent = fs.readFileSync(filePath);
+        const fileContent = await fs.readFile(filePath);
         const compressedContent = zlib.deflateSync(fileContent);
         archive[folderKey][file] = compressedContent;
         break;
       }/*  else if(stats.isDirectory()) {
-        processFolder(filePath, folderKey);
+        await processFolder(filePath, folderKey);
       } */
     }
   }
 
-  processFolder(folderPath);
+  await processFolder(folderPath);
 
   const compressedArchive = zlib.gzipSync(JSON.stringify(archive));
   return compressedArchive;


### PR DESCRIPTION
## Summary
- replace synchronous fs methods with promises
- add async/await with error handling for file operations
- improve deployment steps with detailed logging

## Testing
- `pnpm test` (fails: srp.test.ts)
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689cee8d970483298d7272d35accc525