### PR TITLE
fix: sync folder state on dialog deletion

### DIFF
--- a/src/lib/appManagers/appMessagesManager.ts
+++ b/src/lib/appManagers/appMessagesManager.ts
@@ -3681,9 +3681,16 @@ export class AppMessagesManager extends AppManager {
             this.reloadConversationsPeers.delete(peerId);
             c.promise.resolve(undefined);
           }
-        }
 
-        this.dialogsStorage.dropDialogOnDeletion(peerId, threadOrSavedId);
+          const dialog = this.dialogsStorage.getDialogOnly(peerId);
+          const filterId = dialog && this.dialogsStorage.getDialogFilterId(dialog);
+          this.dialogsStorage.dropDialogOnDeletion(peerId);
+          if(filterId !== undefined && filterId !== FOLDER_ID_ALL && !this.dialogsStorage.isVirtualFilter(filterId)) {
+            this.editPeerFolders([peerId], FOLDER_ID_ALL);
+          }
+        } else {
+          this.dialogsStorage.dropDialogOnDeletion(peerId, threadOrSavedId);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure deleting a dialog removes it from folders on server and refreshes settings

## Testing
- `pnpm lint`
- `pnpm test` *(fails: expected Uint8Array ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d05ee67fc8329a26e7441b397536c