### PR TITLE
feat: conditionally enable bundle visualizer

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,12 +70,11 @@ export default defineConfig({
     solidPlugin(),
     handlebarsPlugin as any,
     USE_SSL ? (basicSsl as any)(SSL_CONFIG) : undefined,
-    visualizer({
+    process.env.ANALYZE ? visualizer({
       gzipSize: true,
       template: 'treemap',
-      filename: 'stats.html',
-      open: true
-    })
+      filename: 'stats.html'
+    }) : undefined
   ].filter(Boolean),
   test: {
     // include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],


### PR DESCRIPTION
## Summary
- enable bundle visualizer only when ANALYZE env var is set
- disable automatic opening of stats file

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d0657e1e88329ac49c46a010bf76a