### PR TITLE
feat: add cross-platform clipboard fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ pnpm install
 ```
 This will install all the needed dependencies.
 
+#### Updating MTProto schema
+You can update the MTProto schema with `node schema.js`:
+
+* **macOS**: `node schema.js 1` reads the schema from the clipboard using `pbpaste`.
+* **Linux**: `node schema.js 1` reads the schema from the clipboard using `xclip -selection clipboard -o`. If no clipboard tool is available, provide a file path instead: `node schema.js path/to/schema.json`.
+* **Windows**: `node schema.js 1` reads the schema from the clipboard using PowerShell's `Get-Clipboard`. You can also supply a file path: `node schema.js path\\to\\schema.json`.
+
 
 #### Running web-server
 The server listens on the port specified by the `PORT` environment variable (default `8080`).

--- a/schema.js
+++ b/schema.js
@@ -2,13 +2,27 @@ const {execSync} = require('child_process');
 const {readFileSync, writeFileSync} = require('fs');
 
 const willPaste = process.argv[2] === '1';
-const sourceFile = process.argv[2];
+const sourceFile = willPaste ? process.argv[3] : process.argv[2];
 
 let sourceContent = (() => {
-  if(willPaste) {
-    return execSync('pbpaste', {encoding: 'utf8'});
+  if (willPaste) {
+    let clipboardCmd;
+    if (process.platform === 'darwin') {
+      clipboardCmd = 'pbpaste';
+    } else if (process.platform === 'win32') {
+      clipboardCmd = 'powershell Get-Clipboard';
+    } else {
+      clipboardCmd = 'xclip -selection clipboard -o';
+    }
+    try {
+      return execSync(clipboardCmd, {encoding: 'utf8'});
+    } catch {
+      if (sourceFile) {
+        return readFileSync(sourceFile, 'utf8');
+      }
+    }
   }
-  if(sourceFile) {
+  if (sourceFile) {
     return readFileSync(sourceFile, 'utf8');
   }
 })();


### PR DESCRIPTION
## Summary
- add OS-specific clipboard command fallback for `schema.js`
- document MTProto schema updates for macOS, Linux, and Windows

## Testing
- `pnpm lint`
- `pnpm test` *(fails: src/tests/srp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d094974c88329a1026b2f728b310f