### PR TITLE
feat: switch callback cache to LRU Map

### DIFF
--- a/src/helpers/cacheCallback.ts
+++ b/src/helpers/cacheCallback.ts
@@ -1,9 +1,43 @@
-function cacheCallback<A, T>(callback: (str: A) => T) {
-  const stringResults: any = {}, numberResults: any = {};
-  return (value: A): T => {
-    const key = '_' + value;
-    return (typeof(value) === 'string' ? stringResults : numberResults)[key] ??= callback(value);
-  };
+type CacheOptions = {
+  maxSize?: number;
+  ttl?: number;
+};
+
+/**
+ * Creates a memoized version of the given callback using an LRU cache.
+ * Cached values are stored in a Map with optional TTL and size limit.
+ * Returned function includes a `clear` method to empty the cache manually.
+ */
+function cacheCallback<A, T>(callback: (value: A) => T, options: CacheOptions = {}) {
+  const {maxSize = 100, ttl} = options;
+  const cache = new Map<A, {value: T; expires?: number}>();
+
+  const memoized = ((value: A): T => {
+    const now = Date.now();
+    const cached = cache.get(value);
+    if(cached) {
+      if(!cached.expires || cached.expires > now) {
+        cache.delete(value);
+        cache.set(value, cached);
+        return cached.value;
+      }
+      cache.delete(value);
+    }
+
+    const result = callback(value);
+    const expires = ttl ? now + ttl : undefined;
+    cache.set(value, {value: result, expires});
+    if(cache.size > maxSize) {
+      const oldestKey = cache.keys().next().value;
+      cache.delete(oldestKey);
+    }
+    return result;
+  }) as ((value: A) => T) & {clear: () => void};
+
+  memoized.clear = () => cache.clear();
+
+  return memoized;
 }
 
 export default cacheCallback;
+

--- a/src/tests/cacheCallback.test.ts
+++ b/src/tests/cacheCallback.test.ts
@@ -1,0 +1,48 @@
+import {expect, test, vi} from 'vitest';
+import cacheCallback from '../helpers/cacheCallback';
+
+test('evicts least recently used value when max size exceeded', () => {
+  const spy = vi.fn((x: number) => x * 2);
+  const cached = cacheCallback(spy, {maxSize: 2});
+
+  cached(1);
+  cached(2);
+  cached(1); // 1 becomes most recently used
+  cached(3); // evicts key 2
+
+  expect(spy).toHaveBeenCalledTimes(3);
+
+  cached(2); // key 2 was evicted, so callback runs again
+  expect(spy).toHaveBeenCalledTimes(4);
+});
+
+test('evicts value after ttl expires', () => {
+  vi.useFakeTimers();
+  const spy = vi.fn((x: number) => x + 1);
+  const cached = cacheCallback(spy, {ttl: 100});
+
+  cached(1);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  vi.advanceTimersByTime(50);
+  cached(1);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  vi.advanceTimersByTime(51);
+  cached(1);
+  expect(spy).toHaveBeenCalledTimes(2);
+  vi.useRealTimers();
+});
+
+test('clear method removes stored values', () => {
+  const spy = vi.fn((x: number) => x);
+  const cached = cacheCallback(spy);
+
+  cached(1);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  cached.clear();
+  cached(1);
+  expect(spy).toHaveBeenCalledTimes(2);
+});
+


### PR DESCRIPTION
## Summary
- implement Map-based LRU cache with TTL support and manual clear
- add unit tests for LRU eviction, TTL expiration, and manual clearing

## Testing
- `pnpm lint`
- `npx vitest run` *(fails: src/tests/srp.test.ts)*


------
https://chatgpt.com/codex/tasks/task_e_689d099fedec8329a176761272184aa2