### PR TITLE
refactor: replace cache polyfill with utility

### DIFF
--- a/src/helpers/cacheFn.ts
+++ b/src/helpers/cacheFn.ts
@@ -9,28 +9,20 @@ import ctx from '../environment/ctx';
 type CacheFunction = (...args: any[]) => any;
 const cache: Map<CacheFunction, {result: any, timeout: number}> = new Map();
 
-Function.prototype.cache = function(thisArg, ...args: any[]) {
-  let cached = cache.get(this);
+export default function cacheFn<T, A extends any[], R>(fn: (this: T, ...args: A) => R, thisArg?: T, ...args: A): R {
+  let cached = cache.get(fn);
   if(cached) {
     return cached.result;
   }
 
-  const result = this.apply(thisArg, args as any);
+  const result = fn.apply(thisArg as any, args as any);
 
-  cache.set(this, cached = {
+  cache.set(fn, cached = {
     result,
     timeout: ctx.setTimeout(() => {
-      cache.delete(this);
+      cache.delete(fn);
     }, 60000)
   });
 
   return result;
-};
-
-declare global {
-  interface Function {
-    cache<T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg?: T, ...args: A): R;
-  }
 }
-
-export {};


### PR DESCRIPTION
## Summary
- add standalone `cacheFn` helper for reusable caching
- drop `Function.prototype.cache` polyfill to avoid prototype mutation

## Testing
- `pnpm lint`
- `pnpm test` *(fails: AssertionError in src/tests/srp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d09af0e588329b185c2080e5a65aa