### PR TITLE
Add pnpm CI workflow with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Audit
+        run: pnpm audit --prod
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to install dependencies, lint, test and audit with pnpm cache

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test -- --run` *(fails: 2 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d0a9a4814832990078f71bc045eb9