### PR TITLE
feat: guard encryptable storage in window

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -284,11 +284,11 @@ export default class AppStorage<
 
   private warnAboutSaving() {
     // TODO: Save data only in worker
-    // if(DEBUG && typeof window !== 'undefined' && this.isEncryptable) {
-    //   const message = 'Encryptable storages should not be used in a window client, only in the shared worker. This avoids data mismatches when the lock screen feature is activated';
-    //   this.log.error(message);
-    //   throw new Error(message);
-    // }
+    if(DEBUG && typeof window !== 'undefined' && this.isEncryptable) {
+      const message = 'Encryptable storages should not be used in a window client, only in the shared worker. This avoids data mismatches when the lock screen feature is activated';
+      this.log.error(message);
+      throw new Error(message);
+    }
   }
 
   public set(obj: Partial<Storage>, onlyLocal = false) {


### PR DESCRIPTION
## Summary
- prevent writing to encryptable storages when running in a window during debug to avoid mismatches

## Testing
- `pnpm test run` *(fails: 2 tests failed)*
- `./node_modules/.bin/eslint src/lib/storage.ts`


------
https://chatgpt.com/codex/tasks/task_e_689d1bcef9608329bae4bc553ccd9540