### PR TITLE
Fix media viewer max-height for handhelds

### DIFF
--- a/src/scss/partials/_mediaViewer.scss
+++ b/src/scss/partials/_mediaViewer.scss
@@ -394,11 +394,11 @@ $inactive-opacity: .4;
         height: 100% !important;
         max-width: 100vw !important;
         // max-height: 100vh !important;
-        // TODO: max-height: calc((var(--vh, 1vh) * 100));
+        max-height: calc(var(--vh, 1vh) * 100);
         //height: calc(100% - 100px) !important;
         /* height: calc(100% - 50px) !important;
         top: calc(50% + 25px) !important;
-        
+
         img, video {
           margin-top: -25px;
         } */


### PR DESCRIPTION
## Summary
- ensure centered media viewer fills viewport height on mobile by using `var(--vh)`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: src/tests/srp.test.ts > 2FA hash, 2FA whole)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b76317c83299381db3e4d666eac