### PR TITLE
feat: auto transfer crypto buffers

### DIFF
--- a/src/lib/encryptedStorageLayer.ts
+++ b/src/lib/encryptedStorageLayer.ts
@@ -74,8 +74,7 @@ export default class EncryptedStorageLayer<T extends Database<any>> implements S
       args: [{
         key,
         data: dataAsBuffer
-      }],
-      transfer: [dataAsBuffer.buffer]
+      }]
     });
 
     return result;
@@ -89,8 +88,7 @@ export default class EncryptedStorageLayer<T extends Database<any>> implements S
       args: [{
         key,
         encryptedData: data
-      }],
-      transfer: [data.buffer]
+      }]
     });
 
     const decoded = new TextDecoder().decode(result);

--- a/src/lib/files/cacheStorage.ts
+++ b/src/lib/files/cacheStorage.ts
@@ -83,8 +83,7 @@ export default class CacheStorageController implements FileStorage {
       args: [{
         key,
         data: dataAsBuffer
-      }],
-      transfer: [dataAsBuffer.buffer]
+      }]
     });
     console.log('[my-debug] encryption ended');
 
@@ -104,8 +103,7 @@ export default class CacheStorageController implements FileStorage {
       args: [{
         key,
         encryptedData: dataAsBuffer
-      }],
-      transfer: [dataAsBuffer.buffer]
+      }]
     });
 
     console.log('[my-debug] decryption ended');

--- a/src/lib/mtproto/transports/obfuscation.ts
+++ b/src/lib/mtproto/transports/obfuscation.ts
@@ -159,8 +159,7 @@ export default class Obfuscation {
   private _process = (data: Uint8Array, operation: 'encrypt' | 'decrypt') => {
     return cryptoMessagePort.invokeCryptoNew({
       method: 'aes-ctr-process',
-      args: [{id: this.id, data, operation}],
-      transfer: [data.buffer]
+      args: [{id: this.id, data, operation}]
     }) as Promise<Uint8Array>;
   };
 


### PR DESCRIPTION
## Summary
- automatically collect ArrayBuffer and CryptoKey arguments as transferables when invoking crypto methods
- drop manual transfer lists at call sites

## Testing
- `pnpm lint`
- `pnpm test` *(fails: srp.test.ts)*
- `pnpm tsc --noEmit` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b61404c8329b49985c88896ae34