### PR TITLE
Escape HTML in wrapPlainText and add tests

### DIFF
--- a/src/components/appSearchSuper..ts
+++ b/src/components/appSearchSuper..ts
@@ -1032,7 +1032,7 @@ export default class AppSearchSuper {
 
     if(!title.textContent) {
       // title = new URL(webpage.url).hostname;
-      title.append(wrapPlainText(webPage.display_url.split('/', 1)[0]));
+      title.textContent = wrapPlainText(webPage.display_url.split('/', 1)[0]);
     }
 
     const row = new Row({

--- a/src/components/sidebarLeft/tabs/sharedFolder.ts
+++ b/src/components/sidebarLeft/tabs/sharedFolder.ts
@@ -119,7 +119,7 @@ export class InviteLink {
     if(s.includes('//')) {
       s = url.split('//').slice(1).join('//');
     }
-    this.textElement.replaceChildren(wrapPlainText(s));
+    this.textElement.textContent = wrapPlainText(s);
     this.url = url;
   }
 

--- a/src/lib/richTextProcessor/wrapPlainText.ts
+++ b/src/lib/richTextProcessor/wrapPlainText.ts
@@ -7,9 +7,6 @@
 import {MessageEntity} from '../../layer';
 import encodeSpoiler from './encodeSpoiler';
 
-/**
- * ! This function is still unsafe to use with .innerHTML
- */
 export default function wrapPlainText(text: string, entities: MessageEntity[] = []) {
   entities.forEach((entity) => {
     if(entity._ === 'messageEntitySpoiler') {
@@ -17,16 +14,20 @@ export default function wrapPlainText(text: string, entities: MessageEntity[] = 
     }
   });
 
-  return text;
-  // if(entities?.length) {
-  //   entities = entities.filter((entity) => entity._ === 'messageEntitySpoiler');
-  // }
-
-  // return wrapRichText(text, {
-  //   entities,
-  //   noEncoding: true,
-  //   noTextFormat: true,
-  //   noLinebreaks: true,
-  //   noLinks: true
-  // }).textContent;
+  return text.replace(/[&<>"']/g, (char) => {
+    switch(char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case '\'':
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
 }

--- a/src/tests/wrapPlainText.integration.test.ts
+++ b/src/tests/wrapPlainText.integration.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, test} from 'vitest';
+import wrapPlainText from '../lib/richTextProcessor/wrapPlainText';
+
+describe('wrapPlainText', () => {
+  test('escapes HTML so it is rendered as text', () => {
+    const input = '<img src=x onerror="alert(1)">&';
+    const escaped = wrapPlainText(input);
+    const div = document.createElement('div');
+    div.innerHTML = escaped;
+
+    expect(div.textContent).toBe(input);
+    expect(div.querySelector('img')).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Escape HTML metacharacters in `wrapPlainText`
- Use `textContent` for shared folder URL and web page titles
- Add integration test ensuring HTML characters are rendered literally

## Testing
- `pnpm lint`
- `pnpm test run` *(fails: src/tests/srp.test.ts: 2FA hash, 2FA whole (with negative))*

------
https://chatgpt.com/codex/tasks/task_e_689d1b0cf20883298b65d1eba910e1be