### PR TITLE
feat: add CORS whitelist parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Open `http://localhost:$PORT/` in your browser (for example `http://localhost:80
 
 Run `pnpm run serve` to build the minimized production version of the app and start the server.
 Set a custom port by defining the `PORT` environment variable, e.g. `PORT=3000 pnpm run serve`.
+Specify allowed cross-origin requests with the `CORS_WHITELIST` environment variable. Multiple origins can be comma-separated:
+
+```
+CORS_WHITELIST="https://example.com,https://another.com" pnpm run serve
+```
 Copy `public` folder contents to your web server if deploying separately.
 
 

--- a/server.js
+++ b/server.js
@@ -9,12 +9,14 @@ const cors = require('cors');
 
 const app = express();
 
-const whitelist = process.env.CORS_WHITELIST
-  ? process.env.CORS_WHITELIST.split(',').map((origin) => origin.trim())
-  : [
-      'https://web.telegram.org',
-      'https://t.me'
-    ];
+function parseCorsWhitelist(raw) {
+  return raw ? raw.split(',').map((origin) => origin.trim()).filter(Boolean) : [];
+}
+
+const whitelist = parseCorsWhitelist(process.env.CORS_WHITELIST);
+if (whitelist.length === 0) {
+  console.warn('CORS whitelist is empty; no origins are allowed');
+}
 
 app.use(helmet());
 app.use(


### PR DESCRIPTION
## Summary
- parse `CORS_WHITELIST` env var and warn if empty
- document `CORS_WHITELIST` usage

## Testing
- `pnpm lint`
- `pnpm test` *(fails: src/tests/srp.test.ts > 2FA hash, 2FA whole (with negative))*

------
https://chatgpt.com/codex/tasks/task_e_689d1aff90948329b890c3c432e7c902