### PR TITLE
Handle file read errors and fail fast on missing TLS credentials

### DIFF
--- a/git-serve-server.js
+++ b/git-serve-server.js
@@ -3,6 +3,7 @@
 const https = require('https');
 const http = require('http');
 const fs = require('fs');
+const path = require('path');
 
 const gitstatic = require("./git-serve");
 const express = require("express");
@@ -43,8 +44,18 @@ const useHttp = false;
 const transport = useHttp ? http : https;
 let options = {};
 if(!useHttp) {
-  options.key = fs.readFileSync(__dirname + '/certs/server-key.pem');
-  options.cert = fs.readFileSync(__dirname + '/certs/server-cert.pem');
+  try {
+    options.key = fs.readFileSync(path.join(__dirname, 'certs', 'server-key.pem'));
+  } catch (err) {
+    console.error('Failed to load HTTPS key:', err.message);
+    process.exit(1);
+  }
+  try {
+    options.cert = fs.readFileSync(path.join(__dirname, 'certs', 'server-cert.pem'));
+  } catch (err) {
+    console.error('Failed to load HTTPS certificate:', err.message);
+    process.exit(1);
+  }
 }
 
 console.log(results);

--- a/server.js
+++ b/server.js
@@ -90,8 +90,18 @@ const server = useHttp ? http : https;
 
 let options = {};
 if(!useHttp) {
-  options.key = fs.readFileSync(__dirname + '/certs/server-key.pem');
-  options.cert = fs.readFileSync(__dirname + '/certs/server-cert.pem');
+  try {
+    options.key = fs.readFileSync(path.join(__dirname, 'certs', 'server-key.pem'));
+  } catch (err) {
+    console.error('Failed to load HTTPS key:', err.message);
+    process.exit(1);
+  }
+  try {
+    options.cert = fs.readFileSync(path.join(__dirname, 'certs', 'server-cert.pem'));
+  } catch (err) {
+    console.error('Failed to load HTTPS certificate:', err.message);
+    process.exit(1);
+  }
 }
 
 server.createServer(options, app).listen(port, () => {

--- a/snapshot-server/index.js
+++ b/snapshot-server/index.js
@@ -61,7 +61,13 @@ app.get('/api/snapshots/:filename', (req, res) => {
     return res.status(404).json({error: 'Snapshot not found'});
   }
 
-  const data = fs.readFileSync(filepath, 'utf-8');
+  let data;
+  try {
+    data = fs.readFileSync(filepath, 'utf-8');
+  } catch (err) {
+    console.error('Error reading snapshot file:', err.message);
+    return res.status(500).json({ error: 'Failed to read snapshot' });
+  }
   res.json(JSON.parse(data));
 });
 

--- a/src/scripts/apply_new_lang.js
+++ b/src/scripts/apply_new_lang.js
@@ -20,8 +20,14 @@ https.get('https://translations.telegram.org/en/webk/export', (response) => {
 
     ['lang', 'langSign'].forEach((part) => {
       const path = `../${part}.ts`;
-    
-      let lang = fs.readFileSync(path).toString();
+
+      let lang;
+      try {
+        lang = fs.readFileSync(path).toString();
+      } catch (err) {
+        console.error(`Failed to read file ${path}:`, err.message);
+        process.exit(1);
+      }
 
       const plural = {};
       data.split('\n').forEach((line) => {

--- a/src/scripts/change_version.js
+++ b/src/scripts/change_version.js
@@ -15,7 +15,13 @@ const BUILD_KEY = PREFIX + 'BUILD';
 const VERSION_KEY = PREFIX + 'VERSION';
 const VERSION_FULL_KEY = PREFIX + 'VERSION_FULL';
 
-const envStr = fs.readFileSync('./.env').toString();
+let envStr;
+try {
+  envStr = fs.readFileSync('./.env').toString();
+} catch (err) {
+  console.error('Failed to read .env file:', err.message);
+  process.exit(1);
+}
 const env = {};
 envStr.split('\n').forEach(line => {
   if(!line) return;
@@ -38,7 +44,13 @@ fs.writeFileSync('./.env', lines.join('\n') + '\n', 'utf-8');
 fs.writeFileSync('./public/version', env[VERSION_FULL_KEY], 'utf-8');
 
 if(changelog) {
-  const data = fs.readFileSync('./CHANGELOG.md');
+  let data;
+  try {
+    data = fs.readFileSync('./CHANGELOG.md');
+  } catch (err) {
+    console.error('Failed to read CHANGELOG.md:', err.message);
+    process.exit(1);
+  }
   const fd = fs.openSync('./CHANGELOG.md', 'w+');
   const lines = [
     `### ${env[VERSION_FULL_KEY]}`

--- a/src/scripts/emoji_compile_regex.js
+++ b/src/scripts/emoji_compile_regex.js
@@ -1,7 +1,13 @@
 // @ts-check
 const fs = require('fs');
 
-const data = fs.readFileSync(__dirname + '/in/emoji_test.txt').toString();
+let data;
+try {
+  data = fs.readFileSync(__dirname + '/in/emoji_test.txt').toString();
+} catch (err) {
+  console.error('Failed to read emoji_test.txt:', err.message);
+  process.exit(1);
+}
 
 /** @type {number[][]} */
 const codepoints = [];

--- a/src/scripts/format_lang.js
+++ b/src/scripts/format_lang.js
@@ -18,13 +18,19 @@ let out = '';
 ['lang', 'langSign'].forEach(part => {
   const path = `../${part}.ts`;
 
-  let str = fs.readFileSync(path).toString()
-  .replace(/\s+\/\/.+/g, '')
-  // .replace(/\\'/g, '')
-  .replace(/"/g, `\\"`)
-  // .replace(/'/g, '"')
-  .replace(/([^\\])'/g, '$1"')
-  .replace(/\\'/g, '\'')
+  let str;
+  try {
+    str = fs.readFileSync(path).toString()
+    .replace(/\s+\/\/.+/g, '')
+    // .replace(/\\'/g, '')
+    .replace(/"/g, `\\"`)
+    // .replace(/'/g, '"')
+    .replace(/([^\\])'/g, '$1"')
+    .replace(/\\'/g, '\'');
+  } catch (err) {
+    console.error(`Failed to read file ${path}:`, err.message);
+    process.exit(1);
+  }
   // .replace(/"(.+?)(?:")(.*?)"/g, '"$1\"$2"');
   {
     const pattern = '= {';

--- a/src/scripts/generate_changelog.js
+++ b/src/scripts/generate_changelog.js
@@ -14,7 +14,13 @@ fs.rmSync(logsPath, {force: true, recursive: true});
 fs.mkdirSync(logsPath);
 
 const processChangelog = (fileName) => {
-  const text = fs.readFileSync('./' + fileName).toString('utf-8');
+  let text;
+  try {
+    text = fs.readFileSync('./' + fileName).toString('utf-8');
+  } catch (err) {
+    console.error(`Failed to read file ${fileName}:`, err.message);
+    process.exit(1);
+  }
 
   const lang = (fileName.split('_')[1] || 'en').split('.')[0];
   const writeTo = `${logsPath}${lang}_{VERSION}.md`;

--- a/src/scripts/icomoon/icomoon_generate.js
+++ b/src/scripts/icomoon/icomoon_generate.js
@@ -14,7 +14,13 @@ function moveFiles(outPath) {
   const stylesOutPath = path.join(__dirname, '../../scss/tgico/_');
   const tsOutPath = path.join(__dirname, '../../icons.ts');
 
-  let styleText = fs.readFileSync(outPath + 'style.scss').toString();
+  let styleText;
+  try {
+    styleText = fs.readFileSync(outPath + 'style.scss').toString();
+  } catch (err) {
+    console.error('Failed to read style.scss:', err.message);
+    process.exit(1);
+  }
   styleText = styleText
   .replace(/icomoon/g, 'tgico')
   // .replace('.tgico {', '.tgico:before {')
@@ -34,7 +40,13 @@ function moveFiles(outPath) {
   styleText = styleText.slice(0, idx + p.length) + '\n';
   fs.writeFileSync(stylesOutPath + 'style.scss', styleText);
 
-  let variablesText = fs.readFileSync(outPath + 'variables.scss').toString();
+  let variablesText;
+  try {
+    variablesText = fs.readFileSync(outPath + 'variables.scss').toString();
+  } catch (err) {
+    console.error('Failed to read variables.scss:', err.message);
+    process.exit(1);
+  }
   variablesText = variablesText.slice(variablesText.indexOf('\n\n') + 2);
   const variables = variablesText.split('\n');
   const jsVariables = {}, o = [];

--- a/src/scripts/split_emoji_versions.js
+++ b/src/scripts/split_emoji_versions.js
@@ -2,7 +2,13 @@
 const fs = require('fs');
 
 // get emoji-test from here: https://unicode.org/Public/emoji/
-const data = fs.readFileSync(__dirname + '/in/emoji-test.txt').toString();
+let data;
+try {
+  data = fs.readFileSync(__dirname + '/in/emoji-test.txt').toString();
+} catch (err) {
+  console.error('Failed to read emoji-test.txt:', err.message);
+  process.exit(1);
+}
 
 const versions = {};
 data.split('\n').forEach((line) => {


### PR DESCRIPTION
## Summary
- wrap `fs.readFileSync` usages in `try/catch`
- abort startup when HTTPS key or certificate can't be loaded
- surface read failures in utility scripts and snapshot server

## Testing
- `pnpm lint`
- `pnpm test` *(fails: AssertionError in srp.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f51308483299a86c4fe9fa701b3