### PR TITLE
feat: add bounded cache for loaded images

### DIFF
--- a/src/components/emoticonsDropdown/tabs/emoji.ts
+++ b/src/components/emoticonsDropdown/tabs/emoji.ts
@@ -50,9 +50,10 @@ import flatten from '../../../helpers/array/flatten';
 import SuperStickerRenderer from './SuperStickerRenderer';
 import StickersTab from './stickers';
 import {PAID_REACTION_EMOJI_DOCID} from '../../../lib/customEmoji/constants';
+import LRUCache from '../../../helpers/lruCache';
 
-
-const loadedURLs: Set<string> = new Set();
+const loadedURLs = new LRUCache<string, true>(100);
+export const purgeLoadedEmojiUrl = (url: string) => loadedURLs.delete(url);
 export function appendEmoji(_emoji: AppEmoji, unify = false) {
   if(_emoji.docId) {
     const customEmojiElement = CustomEmojiElement.create(_emoji.docId);
@@ -107,7 +108,7 @@ export function appendEmoji(_emoji: AppEmoji, unify = false) {
 
           spanEmoji.classList.remove('empty');
 
-          loadedURLs.add(url);
+          loadedURLs.set(url, true);
         });
       }, {once: true});
 

--- a/src/helpers/dom/renderImageFromUrl.ts
+++ b/src/helpers/dom/renderImageFromUrl.ts
@@ -8,7 +8,10 @@ import onMediaLoad from '../onMediaLoad';
 
 // import { getHeavyAnimationPromise } from "../../hooks/useHeavyAnimationCheck";
 
-export const loadedURLs: {[url: string]: boolean} = {};
+import LRUCache from '../lruCache';
+
+export const loadedURLs = new LRUCache<string, true>(100);
+export const purgeLoadedUrl = (url: string) => loadedURLs.delete(url);
 const set = (elem: HTMLElement | HTMLImageElement | SVGImageElement | HTMLVideoElement, url: string) => {
   if(elem instanceof HTMLImageElement || elem instanceof HTMLVideoElement) elem.src = url;
   else if(elem instanceof SVGImageElement) elem.setAttributeNS(null, 'href', url);
@@ -51,7 +54,7 @@ export default function renderImageFromUrl(
     elem.style.opacity = prevOpacity;
   };
 
-  if(loadedURLs[url] && useCache) {
+  if(loadedURLs.has(url) && useCache) {
     set(elem, url);
     requestAnimationFrame(() => {
       elem.style.opacity = prevOpacity || '';
@@ -67,7 +70,7 @@ export default function renderImageFromUrl(
   const onLoad = () => {
     set(elem, url);
 
-    loadedURLs[url] = true;
+    loadedURLs.set(url, true);
     processImageOnLoad?.(loader);
 
     requestAnimationFrame(() => {

--- a/src/helpers/lruCache.ts
+++ b/src/helpers/lruCache.ts
@@ -1,0 +1,40 @@
+export default class LRUCache<K, V> {
+  private cache = new Map<K, V>();
+  constructor(private maxSize = 100) {}
+
+  has(key: K): boolean {
+    if(!this.cache.has(key)) {
+      return false;
+    }
+    const value = this.cache.get(key)!;
+    this.cache.delete(key);
+    this.cache.set(key, value);
+    return true;
+  }
+
+  get(key: K): V | undefined {
+    if(this.has(key)) {
+      return this.cache.get(key);
+    }
+    return undefined;
+  }
+
+  set(key: K, value: V): void {
+    if(this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+    this.cache.set(key, value);
+    if(this.cache.size > this.maxSize) {
+      const oldestKey = this.cache.keys().next().value as K;
+      this.cache.delete(oldestKey);
+    }
+  }
+
+  delete(key: K): void {
+    this.cache.delete(key);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
## Summary
- replace global loadedURLs object with a bounded LRU cache and expose purge helper
- reuse the new LRU cache for emoji image loading
- introduce generic `LRUCache` helper

## Testing
- `npx eslint src/helpers/lruCache.ts src/helpers/dom/renderImageFromUrl.ts src/components/emoticonsDropdown/tabs/emoji.ts`
- `pnpm test` *(fails: expected Uint8Array to deeply equal ...)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f473d288329916e4db92ea279ab