### PR TITLE
feat: add dark theme support and toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="msapplication-TileImage" content="assets/img/mstile-144x144.png?v=jw3mK7G9Ry">
     <meta name="msapplication-config" content="browserconfig.xml?v=jw3mK7G9Ry">
     <meta name="theme-color" content="#ffffff">
-    <meta name="color-scheme" content="light">
+    <meta name="color-scheme" content="light dark">
     <meta name="google" content="notranslate">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: blob:; script-src 'self'; style-src 'self'; font-src 'self'; connect-src 'self';" />
     <!-- <meta name="robots" content="noindex"> -->

--- a/src/components/sidebarLeft/tabs/generalSettings.ts
+++ b/src/components/sidebarLeft/tabs/generalSettings.ts
@@ -337,37 +337,20 @@ export default class AppGeneralSettingsTab extends SliderSuperTabEventable {
       const form = document.createElement('form');
       form.style.marginTop = '.5rem';
 
-      const name = 'theme';
       const stateKey = joinDeepPath('settings', 'theme');
 
-      const dayRow = new Row({
-        radioField: new RadioField({
-          langKey: 'ThemeDay',
-          name,
-          value: 'day',
-          stateKey
-        })
+      const darkModeRow = new Row({
+        titleLangKey: 'DarkMode',
+        checkboxFieldOptions: {
+          toggle: true,
+          stateKey,
+          stateValues: ['system', 'night'],
+          listenerSetter: this.listenerSetter
+        },
+        listenerSetter: this.listenerSetter
       });
 
-      const nightRow = new Row({
-        radioField: new RadioField({
-          langKey: 'ThemeNight',
-          name,
-          value: 'night',
-          stateKey
-        })
-      });
-
-      const systemRow = new Row({
-        radioField: new RadioField({
-          langKey: 'AutoNightSystemDefault',
-          name,
-          value: 'system',
-          stateKey
-        })
-      });
-
-      this.listenerSetter.add(rootScope)('settings_updated', ({key, value, settings}) => {
+      this.listenerSetter.add(rootScope)('settings_updated', ({key}) => {
         if(key === stateKey) {
           rootScope.dispatchEvent('theme_change');
         }
@@ -406,7 +389,7 @@ export default class AppGeneralSettingsTab extends SliderSuperTabEventable {
         }
       });
 
-      form.append(dayRow.container, nightRow.container, systemRow.container);
+      form.append(darkModeRow.container);
 
       container.append(
         themesContainer,

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -310,9 +310,7 @@
 
   // * Day theme end
 }
-
-.night {
-//:root {
+@mixin dark-theme {
   // * Night theme
   --body-background-color: #181818;
   --body-background-color-rgb: 24, 24, 24;
@@ -350,6 +348,16 @@
   // * Night theme end
 }
 
+.night {
+  @include dark-theme;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    @include dark-theme;
+  }
+}
+
 .chat {
   --message-highlighting-color: hsla(85.5319, 36.9171%, 40.402%, .4);//rgba(77, 142, 80, .4);
   --message-highlighting-hover-color: rgba(var(--message-highlighting-color-rgb), calc(var(--message-highlighting-alpha) + .24));
@@ -375,8 +383,7 @@
   --message-out-selection-background-color: var(--selection-background-color);
   --message-out-reaction-tag-dot-color: var(--message-reaction-tag-dot-color);
 }
-
-.night .chat {
+@mixin dark-chat {
   --message-time-color: var(--secondary-text-color);
   --message-checkbox-color: var(--primary-color);
   --message-checkbox-border-color: #fff;
@@ -392,6 +399,16 @@
   --message-out-selection-background-color: rgba(var(--surface-color-rgb), .4);
   // --message-out-reaction-tag-dot-color: rgba(var(--message-out-background-color-rgb), 1);
   --message-out-reaction-tag-dot-color: var(--message-out-background-color);
+}
+
+.night .chat {
+  @include dark-chat;
+}
+
+@media (prefers-color-scheme: dark) {
+  .chat {
+    @include dark-chat;
+  }
 }
 
 @import "components/prism";

--- a/src/tests/theme.test.ts
+++ b/src/tests/theme.test.ts
@@ -1,0 +1,14 @@
+import {describe, it, expect} from 'vitest';
+import sass from 'sass';
+
+const css = sass.compile('src/scss/style.scss').css.toString();
+
+describe('theme variables', () => {
+  it('includes light theme variables', () => {
+    expect(css).toMatch(/:root\s*{[\s\S]*--body-background-color: #fff;[\s\S]*}/);
+  });
+
+  it('includes dark theme variables with prefers-color-scheme', () => {
+    expect(css).toMatch(/@media \(prefers-color-scheme: dark\)\s*{\s*:root\s*{[\s\S]*--body-background-color: #181818;[\s\S]*}\s*}/);
+  });
+});


### PR DESCRIPTION
## Summary
- support light and dark color schemes with prefers-color-scheme
- allow users to force dark theme via settings toggle
- add tests covering light and dark theme variables

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: AssertionError in srp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d1b2f6a9c8329b77351b4437ae891