### PR TITLE
Handle invalid JSON payloads in server

### DIFF
--- a/server.js
+++ b/server.js
@@ -80,6 +80,12 @@ app.use(rateLimit({
   max: 100,
 }));
 app.use(express.json({ limit: '1mb' }));
+app.use((err, req, res, next) => {
+  if (err instanceof SyntaxError && err.status === 400 && 'body' in err) {
+    return res.status(400).json({ message: 'Invalid JSON payload' });
+  }
+  next(err);
+});
 app.use(express.static(publicFolderName));
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- add middleware catching SyntaxError from express.json
- return 400 with a clear "Invalid JSON payload" message

## Testing
- `pnpm test` (fails: AssertionError)
- `pnpm run lint` (fails: object-curly-spacing)


------
https://chatgpt.com/codex/tasks/task_e_689d23563dd08329958d6f06609eeb99