### PR TITLE
feat: add sampling rate to average color helpers

### DIFF
--- a/src/helpers/averageColor.ts
+++ b/src/helpers/averageColor.ts
@@ -6,30 +6,32 @@
 
 import {renderImageFromUrlPromise} from './dom/renderImageFromUrl';
 
-export function averageColorFromCanvas(canvas: HTMLCanvasElement) {
+export function averageColorFromCanvas(canvas: HTMLCanvasElement, samplingRate = 1) {
   const context = canvas.getContext('2d');
 
   const pixel = new Array(4).fill(0);
   const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data;
-  const pixelsLength = pixels.length / 4;
-  for(let i = 0; i < pixels.length; i += 4) {
+  const step = Math.max(1, samplingRate) * 4;
+  let count = 0;
+  for(let i = 0; i < pixels.length; i += step) {
     // const alphaPixel = pixels[i + 3];
     pixel[0] += pixels[i]/*  * (alphaPixel / 255) */;
     pixel[1] += pixels[i + 1]/*  * (alphaPixel / 255) */;
     pixel[2] += pixels[i + 2]/*  * (alphaPixel / 255) */;
     pixel[3] += pixels[i + 3];
+    count++;
   }
 
   const outPixel = new Uint8ClampedArray(4);
-  outPixel[0] = pixel[0] / pixelsLength;
-  outPixel[1] = pixel[1] / pixelsLength;
-  outPixel[2] = pixel[2] / pixelsLength;
-  outPixel[3] = pixel[3] / pixelsLength;
+  outPixel[0] = pixel[0] / count;
+  outPixel[1] = pixel[1] / count;
+  outPixel[2] = pixel[2] / count;
+  outPixel[3] = pixel[3] / count;
   // outPixel[3] = 255;
   return outPixel;
 }
 
-export function averageColorFromImageSource(imageSource: CanvasImageSource, width: number, height: number) {
+export function averageColorFromImageSource(imageSource: CanvasImageSource, width: number, height: number, samplingRate = 1) {
   const canvas = document.createElement('canvas');
   const ratio = width / height;
   const DIMENSIONS = 50;
@@ -45,15 +47,15 @@ export function averageColorFromImageSource(imageSource: CanvasImageSource, widt
 
   const context = canvas.getContext('2d');
   context.drawImage(imageSource, 0, 0, width, height, 0, 0, canvas.width, canvas.height);
-  return averageColorFromCanvas(canvas);
+  return averageColorFromCanvas(canvas, samplingRate);
 }
 
-export function averageColorFromImage(image: HTMLImageElement) {
-  return averageColorFromImageSource(image, image.naturalWidth, image.naturalHeight);
+export function averageColorFromImage(image: HTMLImageElement, samplingRate = 1) {
+  return averageColorFromImageSource(image, image.naturalWidth, image.naturalHeight, samplingRate);
 }
 
-export async function averageColor(imageUrl: string) {
+export async function averageColor(imageUrl: string, samplingRate = 1) {
   const img = document.createElement('img');
   await renderImageFromUrlPromise(img, imageUrl, false);
-  return averageColorFromImage(img);
+  return averageColorFromImage(img, samplingRate);
 };


### PR DESCRIPTION
## Summary
- add optional `samplingRate` to average color helpers
- sample every nth pixel when computing image average color

## Testing
- `pnpm exec eslint src/helpers/averageColor.ts`
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_689d236c6c448329a919619337381bea