### PR TITLE
ci: fail on audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,3 @@ jobs:
 
       - name: Audit
         run: pnpm audit --prod
-        continue-on-error: true


### PR DESCRIPTION
## Summary
- enforce pnpm audit failures in CI by removing `continue-on-error`

## Testing
- `pnpm lint` *(fails: object-curly-spacing in markdownHistory.test.ts)*
- `pnpm test` *(fails: srp.test.ts mismatched Uint8Array values)*
- `pnpm audit --prod`


------
https://chatgpt.com/codex/tasks/task_e_689d237c68188329b9b6cc8794da26fc