### PR TITLE
Expand static file caching

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,13 +61,28 @@ const port = forcePort ? +forcePort : (+process.env.PORT || (thirdTour ? 8443 : 
 app.set('etag', false);
 app.use((req, res, next) => {
   const ext = path.extname(req.path).toLowerCase();
-  const cacheableExtensions = ['.js', '.css', '.png', '.jpg'];
+  const cacheableExtensions = [
+    '.js',
+    '.css',
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.svg',
+    '.webp',
+    '.ico',
+    '.woff',
+    '.woff2',
+    '.ttf',
+    '.otf',
+    '.wasm'
+  ];
   if (cacheableExtensions.includes(ext)) {
     const filename = path.basename(req.path, ext);
     const hasHash = /[.-][0-9a-f]{8,}$/i.test(filename);
     res.set(
       'Cache-Control',
-      hasHash ? 'public, max-age=31536000, immutable' : 'no-store'
+      hasHash ? 'public, max-age=31536000, immutable' : 'public, max-age=300'
     );
   } else {
     res.set('Cache-Control', 'no-store');


### PR DESCRIPTION
## Summary
- broaden `cacheableExtensions` to include more static asset types like SVG, WebP and WASM
- apply immutable long-term caching for hashed assets and short-term caching otherwise

## Testing
- `pnpm test -- --run` *(fails: 2 tests)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689d23a745f48329b4a000a0874fc3c3