### PR TITLE
feat: default to https and enable hsts

### DIFF
--- a/server.js
+++ b/server.js
@@ -53,10 +53,16 @@ app.use((err, req, res, next) => {
 
 const thirdTour = process.argv[2] == 3;
 const forcePort = process.argv[3];
-const useHttp = process.argv[4] !== 'https';
+// Use HTTPS by default; enable HTTP only when explicitly flagged
+const useHttp = process.argv[4] === 'http';
 
 const publicFolderName = thirdTour ? 'public3' : 'public';
 const port = forcePort ? +forcePort : (+process.env.PORT || (thirdTour ? 8443 : 8080));
+
+// Apply HSTS when running over HTTPS
+if (!useHttp) {
+  app.use(helmet.hsts({ maxAge: 31536000 }));
+}
 
 app.set('etag', false);
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- default to HTTPS unless `http` is passed as a flag
- add HSTS middleware with one-year max-age when using HTTPS

## Testing
- `pnpm lint` *(fails: There should be no space after '{' at src/tests/markdownHistory.test.ts:4:29)*
- `pnpm test` *(fails: expected Uint8Array to deeply equal ... in src/tests/srp.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d239974e88329a6a1918306ba9654